### PR TITLE
meteorite not being added /meteor/.gitIgnore

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -188,10 +188,10 @@ Project.prototype.execute = function(args, fn) {
 
 Project.prototype._addToGitIgnore = function() {
 
+  var gitignorePath = path.join(this.meteorRoot, '.gitignore');
   if (!fs.existsSync(gitignorePath))
     return;
   
-  var gitignorePath = path.join(this.meteorRoot, '.gitignore');
   var gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
   
   // Add ./.meteor/meteorite to ./.meteor/.gitignore


### PR DESCRIPTION
I changed the order so the definition was first as `!fs.existsSync(gitignorePath)` was always return and never adding it.
