### PR TITLE
Check for undefined libPath

### DIFF
--- a/lib/dependencies/package.js
+++ b/lib/dependencies/package.js
@@ -101,6 +101,11 @@ Package.prototype.installInto = function(project, fn) {
     
     var linkedTo = false;
     var libPath = self.libPath();
+
+    if (_.isUndefined(libPath)) {
+      throw 'Could not locate package.js within path ' + self.source.packagePath();
+    }
+
     // grr this is harder than it needs to be
     try {
       linkedTo = fs.readlinkSync(packagePath);
@@ -113,7 +118,7 @@ Package.prototype.installInto = function(project, fn) {
       linkedTo = false;
       fs.unlinkSync(packagePath);
     }
-    
+
     // Make link if it doesn't exist, inform caller
     if (! linkedTo && !_.isUndefined(libPath)) {
       fs.symlinkSync(libPath, packagePath);
@@ -171,7 +176,7 @@ Package.prototype.libPath = function(libRoot) {
   libRoot = libRoot || this.source.packagePath();
 
   var libPath;
-  
+
   // TODO: consider using wrench.readdirRecursive for this? (just a suggestion)
   
   // Go spelunking until we find a package.js so


### PR DESCRIPTION
When specifying a (local) package with no package.js libPath is undefined. This results in an exception:

```
fs.js:561
return binding.symlink(preprocessSymlinkDestination(destination, type),
    ^
    TypeError: dest path must be a string
at Object.fs.symlinkSync (fs.js:561:18)
at Package.installInto (/usr/local/lib/node_modules/meteorite/lib/dependencies/package.js:118:10)
at LocalSource.fetch (/usr/local/lib/node_modules/meteorite/lib/sources/local.js:25:3)
at Package.fetch (/usr/local/lib/node_modules/meteorite/lib/dependencies/package.js:79:15)
at Package.installInto (/usr/local/lib/node_modules/meteorite/lib/dependencies/package.js:100:8)
at Dependencies.installInto.installStep (/usr/local/lib/node_modules/meteorite/lib/dependencies/dependencies.js:62:22)
at Dependencies.installInto (/usr/local/lib/node_modules/meteorite/lib/dependencies/dependencies.js:64:3)
at Project.install (/usr/local/lib/node_modules/meteorite/lib/project.js:140:23)
at Project.fetch (/usr/local/lib/node_modules/meteorite/lib/project.js:109:9)
at Resolver.resolve (/usr/local/lib/node_modules/meteorite/lib/dependencies/resolver.js:47:5)
```

This PR just checks for undefined to prevent this exception. The installation of the package will fail silently then.
