### PR TITLE
Add bash completions.

### DIFF
--- a/completions/mrt.bash
+++ b/completions/mrt.bash
@@ -19,6 +19,17 @@ _mrt() {
   bundle"
 
   case "${prev}" in
+    --example)
+      local examples=" \
+      leaderboard \
+      parties \
+      todos \
+      wordplay"
+
+      COMPREPLY=($(compgen -W "${examples}" -- ${cur}))
+      return 0
+      ;;
+
     run)
       local run=" \
       -p \


### PR DESCRIPTION
Depending on how you installed meteorite, add this to your .bashrc (or .bash_profile) to use them:

``` bash
if [ -f /path/to/mrt.bash ]; then
  . /path/to/mrt.bash
fi
```

Also, if accepted, I'll send a pull request for linking the completions up during npm installation.
