### PR TITLE
typo fix for Installing Meteorite section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g meteorite
 If your system requires root access to install global npm packages, make sure you use the `-H` flag:
 
 ``` sh
-$ npm -H install -g meteorite
+$ sudo -H npm install -g meteorite
 ```
 
 ## Updating from pre-0.6.0 Meteorite


### PR DESCRIPTION
The command for installing when root is required had a typo:
`npm -H install -g meteorite`
should be:
`sudo -H npm install -g meteorite`
