### PR TITLE
Fix issue #91: Can't read white text with white-background terminal

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -144,7 +144,7 @@ Project.prototype.install = function(fn, forceUpdate) {
     // Link each package into installRoot
     self.dependencies.installInto(self, function(packagesInstalled) {
       console.log();
-      console.log('Done installing smart packages'.white.bold);
+      console.log('Done installing smart packages'.bold);
       
       // install the smart.lock file
       if (fs.existsSync(self.smartJsonPath) && (self.lockChanged || !fs.existsSync(self.smartLockPath)))
@@ -173,7 +173,7 @@ Project.prototype.execute = function(args, fn) {
     console.suppress();
 
   console.log();
-  console.log("Stand back while Meteorite does its thing".white.bold);
+  console.log("Stand back while Meteorite does its thing".bold);
   
   // TODO -- what do we do here if not installed? I'm not sure we just go ahead
   //   and install, we should probably abort and tell them


### PR DESCRIPTION
Changed white output color back to default to improve readability on white CLIs.
See #91
