### PR TITLE
fixed postinstall in cygwin

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 , "scripts":
   { "test": "mocha spec/unit spec/acceptance -t 240000 -R spec"
   , "flushcache": "rm -rf spec/support/cache"
-  , "postinstall": "./completions/postinstall.sh"
+  , "postinstall": "sh ./completions/postinstall.sh"
   }
 , "repository":
   { "type" : "git"


### PR DESCRIPTION
Error message:

> meteorite@0.6.10 postinstall C:\Users\%username%\AppData\Roaming\npm\node_modules\meteorite
> ./completions/postinstall.sh
> '.' is not recognized as an internal or external command, operable program or batch file.
