### PR TITLE
Fix for package.js in .build directories

### DIFF
--- a/lib/dependencies/package.js
+++ b/lib/dependencies/package.js
@@ -210,7 +210,7 @@ Package.prototype.libPath = function(libRoot) {
     _.each(fs.readdirSync(root), function(fileName) {
       var filePath = path.join(root, fileName);
       var fileStat = fs.lstatSync(filePath);
-      if (fileStat.isDirectory()) {
+      if (fileStat.isDirectory() && fileName !== '.build') {
         findPackage(filePath);
       } else if (fileName === 'package.js') {
         libPath = path.dirname(filePath);


### PR DESCRIPTION
I had quite some issues of meteorite finding `package.js` directory in `.build` directory of packages. As a consequence symlinks in `packages` directory were pointing to `.build` directories of packages, which broke things. It really depends on the system how files are traversed, so if `.build` is before top-level `package.js` or not.

This simple change makes sure it does not try to search in `.build` directory.
