### PR TITLE
Prefixing the [gitgnore] package entry with a "/".

### DIFF
--- a/lib/dependencies/package.js
+++ b/lib/dependencies/package.js
@@ -147,7 +147,7 @@ Package.prototype.addToGitIgnore = function(project) {
   var lines = gitignoreContent.split('\n');
   
   if (! _.any(lines, function(l) { return l === self.name })) {
-    lines.push(self.name);
+    lines.push("/" + self.name);
     lines = _.filter(lines, function(l) { return l !== ''});
     
     gitignoreContent = lines.join('\n') + '\n';


### PR DESCRIPTION
Prefixing the [gitgnore] package entry with a "/" to prevent similarly named descent folders also being ignored.

https://github.com/oortcloud/meteorite/issues/187
