### PR TITLE
Fixed searching for package.js

### DIFF
--- a/lib/dependencies/package.js
+++ b/lib/dependencies/package.js
@@ -208,12 +208,21 @@ Package.prototype.libPath = function(libRoot) {
   var findPackage = function(root) {
     var rootStat = fs.lstatSync(root);
     _.each(fs.readdirSync(root), function(fileName) {
+      if (!_.isUndefined(libPath)) return;
       var filePath = path.join(root, fileName);
       var fileStat = fs.lstatSync(filePath);
-      if (fileStat.isDirectory() && fileName !== '.build') {
+      if (fileStat.isFile()) {
+        if (fileName === 'package.js') {
+          libPath = path.dirname(filePath);
+        }
+      }
+    });
+    _.each(fs.readdirSync(root), function(fileName) {
+      if (!_.isUndefined(libPath)) return;
+      var filePath = path.join(root, fileName);
+      var fileStat = fs.lstatSync(filePath);
+      if (fileStat.isDirectory()) {
         findPackage(filePath);
-      } else if (fileName === 'package.js') {
-        libPath = path.dirname(filePath);
       }
     });
   };


### PR DESCRIPTION
The fix done in #185 for package search was insufficient. modified package.js to search for the file first (breadth first) before searching subdirectories.
