### PR TITLE
workaround for Issue #204 - auto-convert to https for github.com urls

### DIFF
--- a/lib/sources/git.js
+++ b/lib/sources/git.js
@@ -20,6 +20,12 @@ GitSource = function(basePath, config) {
   this.sourcePath = this.sourcePath();
   this.commit = config.commit;
 
+  if (/^http:\/\/github.com/.test(this.url)) {
+    // Use https to avoid 301 redirect issues with older git
+    // Issue 204 - https://github.com/oortcloud/meteorite/issues/204
+    this.url = 'https' + this.url.substring(4)
+  }
+
 };
 GitSource.prototype.packagePath = function() {
   return path.join(this.basePath, this.packageNamespace(), this.commit);


### PR DESCRIPTION
Convert during setup instead of inside _clone so that other commands also avoid the same 301 problem.
