### PR TITLE
Fixed pkg add instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Unlike `meteor add`, only one package can be added at a time with `mrt add`.
 # Add the latest version of the moment package on Atmosphere.
 $ mrt add moment
 # Add a specific version of a package.
-$ mrt add router --version 0.3.4
+$ mrt add router --pkg-version 0.3.4
 # Meteorite will install page.js too, because router depends on it.
 ```
 


### PR DESCRIPTION
In the readme it instructed people to add a specific version of a package using:

```
mrt add package --version 0.0.5
```

This just installed the current version of the package and outputted the version number of meteorite to the console.

The correct way to specify a version of a package is:

```
mrt add package --pkg-version 0.0.2
```
