### PR TITLE
235 - revert to known good wrench version.  tests fail with latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 , "dependencies":
   { "ddp": ">=0.3.1"
   , "underscore": "1.3.3"
-  , "wrench": ">=1.3.9"
+  , "wrench": "1.3.9"
   , "fstream": ">=0.1.18"
   , "optimist": ">=0.3.4"
   , "prompt": "0.2.11"


### PR DESCRIPTION
Fixes issue #235 .  Wrench module version 1.3.9 works but latest version (1.5.4) causes meteorite test suite to fail.  
