### PR TITLE
#241: /spec/lib/atmosphere.js: now it doesn't require 'mrt' in PATH during testing

### DIFF
--- a/spec/lib/atmosphere.js
+++ b/spec/lib/atmosphere.js
@@ -6,7 +6,7 @@ var async = require('async');
 var assert = require('assert');
 
 
-var baseCommand = 'mrt --repoHost localhost --repoPort 3333 --repoUsername test --repoPassword testtest'
+var baseCommand = path.resolve(path.join('bin', 'mrt.js')) + '  --repoHost localhost --repoPort 3333 --repoUsername test --repoPassword testtest';
 
 var packagesNeeded = {
   'mrt-test-pkg1': ['0.1.0', '0.2.0'],


### PR DESCRIPTION
@tmeasday fix for #241. Passes all tests on Debian 7 with no `mrt` in PATH.
