### PR TITLE
spec/support/apps/*: autopublish package was removed, standard-app-packages was added

### DIFF
--- a/spec/support/apps/app-with-nested-smart-pkg-deps-specified-by-paths/.meteor/packages
+++ b/spec/support/apps/app-with-nested-smart-pkg-deps-specified-by-paths/.meteor/packages
@@ -3,6 +3,6 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1
 mrt-test-pkg2

--- a/spec/support/apps/app-with-nested-smart-pkg-deps-that-clash/.meteor/packages
+++ b/spec/support/apps/app-with-nested-smart-pkg-deps-that-clash/.meteor/packages
@@ -3,4 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages

--- a/spec/support/apps/app-with-nested-smart-pkg-deps/.meteor/packages
+++ b/spec/support/apps/app-with-nested-smart-pkg-deps/.meteor/packages
@@ -3,6 +3,6 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1
 mrt-test-pkg2

--- a/spec/support/apps/app-with-smart-json/.meteor/packages
+++ b/spec/support/apps/app-with-smart-json/.meteor/packages
@@ -3,4 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages

--- a/spec/support/apps/app-with-smart-pkg-pinned-to-branch/.meteor/packages
+++ b/spec/support/apps/app-with-smart-pkg-pinned-to-branch/.meteor/packages
@@ -3,5 +3,5 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1

--- a/spec/support/apps/app-with-smart-pkg-pinned-to-ref/.meteor/packages
+++ b/spec/support/apps/app-with-smart-pkg-pinned-to-ref/.meteor/packages
@@ -3,5 +3,5 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1

--- a/spec/support/apps/app-with-smart-pkg-pinned-to-tag/.meteor/packages
+++ b/spec/support/apps/app-with-smart-pkg-pinned-to-tag/.meteor/packages
@@ -3,5 +3,5 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1

--- a/spec/support/apps/app-with-smart-pkg-specified-by-path/.meteor/packages
+++ b/spec/support/apps/app-with-smart-pkg-specified-by-path/.meteor/packages
@@ -3,5 +3,5 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1

--- a/spec/support/apps/app-with-smart-pkg/.meteor/packages
+++ b/spec/support/apps/app-with-smart-pkg/.meteor/packages
@@ -3,5 +3,5 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages
 mrt-test-pkg1

--- a/spec/support/apps/app-without-smart-json/.meteor/packages
+++ b/spec/support/apps/app-without-smart-json/.meteor/packages
@@ -3,4 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages

--- a/spec/support/apps/uninstalled-app-with-smart-json/.meteor/packages
+++ b/spec/support/apps/uninstalled-app-with-smart-json/.meteor/packages
@@ -3,4 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages

--- a/spec/support/apps/uninstalled-app-with-smart-pkg/.meteor/packages
+++ b/spec/support/apps/uninstalled-app-with-smart-pkg/.meteor/packages
@@ -3,4 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-autopublish
+standard-app-packages


### PR DESCRIPTION
Fix for #245. Passes all 126 tests on Debian 7 in five minutes.

I've left `app-with-meteor-*` as is, because they use some old version of Meteor.
