### PR TITLE
install packages with local source only if path exists

### DIFF
--- a/lib/sources/source.js
+++ b/lib/sources/source.js
@@ -6,10 +6,12 @@ var fs = require('fs');
 Source = {
   prepare: function(root, config) {
     var klass;
-    
+
     if (config.path) {
       if (fs.existsSync(config.path))
         klass = LocalSource;
+      else
+        console.log("Warning: Path '"+config.path+"' for package '"+config.name+"' does not exist.");
     }
     if (!klass)
       klass = GitSource;


### PR DESCRIPTION
allow path and git to both be specified in smart.json
install from git if path doesn't exist
