### PR TITLE
create packages directory if it doesn't exist

### DIFF
--- a/lib/meteorite.js
+++ b/lib/meteorite.js
@@ -115,6 +115,10 @@ Meteorite.prototype['link-package'] = function(fn) {
   // pointing to the wrong spot
   if (old)
     fs.unlinkSync(packagePath);
+    
+  // make sure packages directory exists
+  if (!old && !fs.existsSync('packages'))
+    fs.mkdirSync('packages');
   
   fs.symlinkSync(packageDir, packagePath);
 }


### PR DESCRIPTION
Just a little check to allow this:

``` bash
$ meteor create test
$ cd test
$ mrt link-package test-package
```

instead of this

``` bash
$ meteor create test
$ cd test
$ mkdir packages
$ mrt link-package test-package
```
